### PR TITLE
chore(config): ignore testdata and vendor paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "automergeType": "pr",
   "prCreation": "immediate",
   "ignorePresets": [":ignoreModulesAndTests"],
-  "ignorePaths": ["**/node_modules/**", "**/__fixtures__/**", "test/**"],
+  "ignorePaths": ["**/node_modules/**", "**/__fixtures__/**", "**/testdata/**", "**/vendor/**", "test/**"],
   "rebaseWhen": "conflicted",
   "baseBranches": ["$default", "next"],
   "dockerfile": {


### PR DESCRIPTION
## Summary

- Add `**/testdata/**` to `ignorePaths` to skip Go test data directories (e.g. `syft/format/syftjson/testdata/image-alpine/Dockerfile`)
- Add `**/vendor/**` to `ignorePaths` to skip Go vendor directories
- Prevents Renovate from opening unnecessary update PRs for files that should never be updated

## Test plan

- [ ] Verify Renovate no longer creates PRs for files under `testdata/` or `vendor/` paths in downstream repositories